### PR TITLE
Remove margin from top-bar to allow first row headings to link properly.

### DIFF
--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -1,6 +1,7 @@
 body {background: #f5f5f5; margin-bottom: 40px; font-size: 16px; font-family: 'Ubuntu Mono', monospace;}
 h1,h2,h3,h4,h5,h6 {font-family: 'Ubuntu Mono', monospace; }
 .top-bar {background: #333;}
+.fixed .top-bar {margin-bottom:0}
 .top-bar-section li a:not(.button) { background: #333; }
 .top-bar-section li a:not(.button):hover { color: #ddd; }
 .top-bar .name h1 a { color: #fa503a; }


### PR DESCRIPTION
Margin extends down, causing the top row of links to be covered. This removes the bottom margin of the nav, when inside a 'fixed' div.
