### PR TITLE
Removed absolute path from assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet" />
 	<link href='http://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700' rel='stylesheet' type='text/css'>
 	<link rel="shortcut icon" href="assets/ico/favicon.png">
-	<link rel="stylesheet" href="/assets/css/page.css" />
+	<link rel="stylesheet" href="assets/css/page.css" />
 	<title>Laravel Cheat Sheet</title>
 </head>
 <body>
@@ -660,8 +660,8 @@ with(new Foo)->chainedMethod();
 
 		</div>
 	</div>
-	<script src="/assets/js/jquery-1.10.2.min.js"></script>
-	<script src="/assets/js/google-code-prettify/prettify.js"></script>
-	<script type="text/javascript" src="/assets/js/app.js"></script>
+	<script src="assets/js/jquery-1.10.2.min.js"></script>
+	<script src="assets/js/google-code-prettify/prettify.js"></script>
+	<script type="text/javascript" src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
A small little fix allowing the cheatsheets to work correctly both from file system and as a subdirectory within a hosted installation
