### PR TITLE
Wrap pre tags

### DIFF
--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -27,7 +27,7 @@ h1,h2,h3,h4,h5,h6 {font-family: 'UbuntuMono', monospace; }
 /**
  * This prettyprint code is shamelessly stolen from the one and only @daylerees http://laravel.com/css/style.css
  */
- pre{font-family: "Ubuntu Mono", monospace;background-color:#333;padding:5px;font-size:90%;color:#e9e4e5;line-height:1.5em;margin:0.2em 0;border: 0;} 
+ pre{font-family: "Ubuntu Mono", monospace;background-color:#333;padding:5px;font-size:90%;color:#e9e4e5;line-height:1.5em;margin:0.2em 0;border: 0;white-space:pre-wrap;} 
  pre .pln{color:#e9e4e5;}
  pre .str{color:#bcd42a;}
  pre .kwd{color:#4bb1b1;}


### PR DESCRIPTION
A lot of the code is not visible in the browser due to the text not being wrapped. This is especially true on smaller screens.

This will fix the problem by wrapping the text to a new line instead of having it fall off the edge.
