### PR TITLE
Fix strange gap between comment and code in HTML builder section

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,7 +9,7 @@ $(function(){
 	prettyPrint();
 
 	// Shine up the HTML:: calls
-	var $html_elements = $("span.pln:contains('HTML')").removeClass('pln').addClass('typ');
+	var $html_elements = $("span.pln:contains('HTML')").addClass('typ');
 	var $url_elements = $("span.pln:contains('URL')").removeClass('pln').addClass('typ');
 	var $url_elements = $("span.pln:contains('SSH')").removeClass('pln').addClass('typ');
 	var $url_elements = $("span.pln:contains('DB')").addClass('typ');


### PR DESCRIPTION
There was a random gap between the comment and the line of code it was describing, but only in the HTML builder section. Removing the "removeClass('.pln')" method seemed to fix the problem, and still keeps all the other styling intact.