### PR TITLE
Removed deprecated entries in Helpers/URLs and Links section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,16 +1282,8 @@ trans('foo.bar');
 trans_choice('foo.bar', $count);
                 </pre>
                 <h6>URLs and Links</h6>
-                <pre class="prettyprint lang-php">action('FooController@method', $parameters);
-link_to('foo/bar', $title, $attributes, $secure);
-link_to_asset('img/foo.jpg', $title, $attributes, $secure);
-link_to_route('route.name', $title, $parameters, $attributes);
-link_to_action('FooController@method', $title, $params, $attrs);
-// HTML Link
-asset('img/photo.jpg', $title, $attributes);
-// HTTPS link
-secure_asset('img/photo.jpg', $title, $attributes);
-secure_url('path', $parameters);
+                <pre class="prettyprint lang-php">
+action('FooController@method', $parameters);
 route($route, $parameters, $absolute = true);
 url('path', $parameters = array(), $secure = null);
                 </pre>


### PR DESCRIPTION
Since Laravel 5.0 a lot helper functions are deprecated, like "link_to", "link_to_asset", "link_to_route", "link_to_action", "secure_asset", "secure_url".

I removed them, because these helper functions are not comming back and it adds to confusion, if you try to use them and Laravel 5.0 and upwards throws errors.

Compare: http://laravel.com/docs/4.2/helpers#urls
To: http://laravel.com/docs/5.1/helpers#urls

Only three have remained: action(), route(), url().

My suggestions is:
1. Either to keep the cheatsheet up to date with every function there is and used to be in every Laravel Version, without discriminating between what works in each version.
2. Keep the cheatsheet current to the most modern Laravel Major Version and change the cheatsheet from Laravel 4 to Laravel 5 to Laravel 6 accordingly, thus now removing what belongs to Laravel 4 and keeping only what belongs to Laravel 5.
3. Make the cheatsheet versioned, that means to provide a different html file for each Laravel version and link to each accordingly.

What do you think?
