### PR TITLE
Remove the link to Laravel 3 and add a link to Laravel 5.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,13 +32,13 @@
                             <a href="#">Laravel Docs</a>
                             <ul class="dropdown">
                                 <li>
-                                    <a href="http://three.laravel.com/" target="_blank"><i class="icon-file-text"></i> Laravel 3 Docs</a>
-                                </li>
-                                <li>
                                     <a href="http://laravel.com/docs/4.2" target="_blank"><i class="icon-file-text"></i> Laravel 4 Docs</a>
                                 </li>
                                 <li>
                                     <a href="http://laravel.com/docs/5.0" target="_blank"><i class="icon-file-text"></i> Laravel 5 Docs</a>
+                                </li>
+                                <li>
+                                    <a href="http://laravel.com/docs/5.1" target="_blank"><i class="icon-file-text"></i> Laravel 5.1 Docs</a>
                                 </li>
                             </ul>
                         </li>


### PR DESCRIPTION
Remove the link to the documentation of Laravel 3 and add a link to the documentation from Laraval 5.1
The link to the documentation of Laravel 3 is dead